### PR TITLE
Updating Particle (Spark) compatibility

### DIFF
--- a/GPRMC.cpp
+++ b/GPRMC.cpp
@@ -1,36 +1,39 @@
 /*
  Copyright 2013 Daniele Faugiana
- 
+
  This file is part of "WiGPS Arduino Library".
- 
+
  "WiGPS Arduino Library" is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  "WiGPS Arduino Library" is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with "WiGPS Arduino Library". If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "GPRMC.h"
-#include "application.h"
-//#include "arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <arduino.h>
+#elif defined(SPARK)
+#include "application.h" //needs to be placed in extra classes
+#endif
 
+#include "GPRMC.h"
 
 GPRMC::GPRMC(char* gprmc) : String(gprmc){
     /*
      * Initialize the oject and parse the incoming String
      * looking for all commas in the String.
      */
-    
+
     int p = 0;
     int* c = commas;
-    
+
     for(int i = 0; i<COMMAS_NUMBER; i++){
         p = this->indexOf(',', p);
         if(p == -1){
@@ -43,7 +46,7 @@ GPRMC::GPRMC(char* gprmc) : String(gprmc){
             *(c++) = (p++);
         }
     }
-    
+
     p = this->indexOf('*') + 1;
     if(p > 0){
         stringChecksum = this->substring(p).toInt();
@@ -63,11 +66,11 @@ int GPRMC::checksum(void){
         ret_value = CHECKSUM_NOT_PERFORMED;
     }
     else{
-        
+
         // Perform the checksum and select what to return
-        
+
     }
-    
+
     return ret_value;
 }
 
@@ -78,7 +81,7 @@ String GPRMC::findElements(int elementNumber){
      * from the raw GPRMC String. Then, extract
      * a subString and return it
      */
-    
+
     // Get the comma right BEFORE the selected element
     int startComma = commas[elementNumber-1];
     // Get the comma right AFTER the selected element

--- a/GPRMC.h
+++ b/GPRMC.h
@@ -1,32 +1,41 @@
 /*
  Copyright 2013 Daniele Faugiana
- 
+
  This file is part of "WiGPS Arduino Library".
- 
+
  "WiGPS Arduino Library" is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  "WiGPS Arduino Library" is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with "WiGPS Arduino Library". If not, see <http://www.gnu.org/licenses/>.
  */
-#include "application.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <arduino.h>
+#elif defined(SPARK)
+#include "application.h" //needs to be placed in extra classes
+#endif
 
 #ifndef _GPRMC_H
 #define _GPRMC_H
 
-//#include <arduino.h>
+
 
 #define COMMAS_NUMBER 12
 
-#define TRUE  1
+#if !defined TRUE
+#define TRUE 1
+#endif
+
+#if !defined FALSE
 #define FALSE 0
+#endif
 
 #define CHECKSUM_VALID          1
 #define CHECKSUM_NOT_PERFORMED  0
@@ -48,27 +57,27 @@ typedef unsigned int uint;
 
 
 class GPRMC: public String {
-    
+
     /*
      * This class inherits from the C++
      * String class and expands it to manipulate
      * particular types of Strings which are
      * GPRMC String from the NMEA protocol.
      */
-    
+
 private:
-    
+
     int commas[COMMAS_NUMBER];  // Array of commas positions in the raw String
     int stringChecksum;         // The String checksum received value
-    
+
     String findElements(int);       // Internal element finder for the parsing
-    
+
 public:
-    
+
     GPRMC(char*);
-    
+
     int checksum(void);         // Check if the String is valid or not
-    
+
     String UTCtime(void);       // Return the UTC time
     String dataValid(void);     // Return the data valid character
     String UTCdate(void);       // Return the UTC date
@@ -79,8 +88,8 @@ public:
     String course(void);        // Return the course degrees
     String speed(void);         // Return the speed in knots
     String opMode(void);        // Return the operation mode
-    
-    
+
+
 };
 
 #endif

--- a/WiGPS.cpp
+++ b/WiGPS.cpp
@@ -1,22 +1,25 @@
 /*
  Copyright 2013 Daniele Faugiana
- 
+
  This file is part of "WiGPS Arduino Library".
- 
+
  "WiGPS Arduino Library" is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  "WiGPS Arduino Library" is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with "WiGPS Arduino Library". If not, see <http://www.gnu.org/licenses/>.
  */
+#if defined(SPARK)
 #include "application.h"
+#endif
+
 #include "WiGPS.h"
 
 void WiGPS::parseGPRMC(GPRMC* str){
@@ -24,33 +27,33 @@ void WiGPS::parseGPRMC(GPRMC* str){
      * Save all data from the GPRMC string
      * in a numeric format in memory.
      */
-    
+
     hours = str->UTCtime().substring(0,2).toInt();
     minutes = str->UTCtime().substring(2,4).toInt();
     seconds = str->UTCtime().substring(4,6).toInt();
-    
+
     day = str->UTCdate().substring(0,2).toInt();
     month = str->UTCdate().substring(2,4).toInt();
     year = str->UTCdate().substring(4,6).toInt();
-    
+
     latitudeDeg = str->latitudeDeg().substring(0,2).toInt();
     latitudeMin = str->latitudeDeg().substring(2,4).toInt();
     latitudeSec = str->latitudeDeg().substring(5,6).toInt();
     latitudeRef = str->latitudeRef().charAt(0);
-    
+
     longitudeDeg = str->longitudeDeg().substring(0,3).toInt();
     longitudeMin = str->longitudeDeg().substring(3,5).toInt();
     longitudeSec = str->longitudeDeg().substring(6,7).toInt();
     longitudeRef = str->longitudeRef().charAt(0);
-    
+
     String speedString(str->speed());
     int speedDot = speedString.indexOf('.');
     Speed = speedString.substring(0,speedDot).toInt();
-    
+
     String courseString(str->course());
     int courseDot = courseString.indexOf('.');
     Course = courseString.substring(0,courseDot).toInt();
-    
+
     return;
 }
 
@@ -61,7 +64,7 @@ void WiGPS::parseGPRMC(GPRMC* str){
 
 
 WiGPS::WiGPS(int pw){
-    
+
     return;
 }
 void WiGPS::init(int pw) {
@@ -79,7 +82,7 @@ int WiGPS::on(void){
      * starts watching for satellites
      * to retrieve data from them
      */
-    
+
     //int timeout = 3;
     int counter = 0;
     digitalWrite(powerPort, HIGH);
@@ -102,7 +105,7 @@ int WiGPS::off(void){
      * and RAM memory data for future
      * exploring.
      */
-    
+
     //int timeout = 3;
     int counter = 0;
     digitalWrite(powerPort, LOW);
@@ -127,25 +130,25 @@ bool WiGPS::update(void){
      * After retrieving a "valid" String the
      * parser is called.
      */
-    
+
     char buffer[BUFFER_LENGTH_2];
     char *buf = buffer;
     int dataReady = FALSE;
     int failed5 = 0;
-    
-    
+
+
     while(buf - buffer < BUFFER_LENGTH_2){
         *(buf++) = '\0';
     }
     buf = buffer;
-    
+
     while(!dataReady){
         // Wait for the first incoming header
         while(Serial1.read() != '$');
         // Store the first 5 chars
         for(int i = 0; i<5; i++){
             while(!Serial1.available());
-            
+
             *(buf++) = Serial1.read();
         }
         //Serial.println("buffer:");
@@ -158,16 +161,16 @@ bool WiGPS::update(void){
                 while(!Serial1.available());
                 *buf = Serial1.read();
             } while(*(buf++) != '\n');
-            
+
             GPRMC str(buffer);
             Serial.println(str);
-            
+
             if(str.dataValid().equals("A")){
                 // The string is ok, extract data
                 // TODO: ADD CHECKSUM CONTROL TO THE STRING
                 //Serial.println(str);
                 parseGPRMC(&str);
-                
+
                 //Now break the cycle
                 dataReady = TRUE;
                 return dataReady;
@@ -180,7 +183,7 @@ bool WiGPS::update(void){
         //     Serial.println("7- Too many fails.. quitting ");
         //     return TRUE;
         // }
-        
+
         buf = buffer;
     };
     return TRUE;
@@ -193,7 +196,7 @@ String WiGPS::time(void){
      * last updated data in the memory
      * in the format of the String d
      */
-    
+
     String h(hours);
     String m(minutes);
     //String s(seconds);
@@ -208,7 +211,7 @@ String WiGPS::date(void){
      * last updated data in the memory
      * in the format of the String d
      */
-    
+
     String d(day);
     String m(month);
     //String y(year);
@@ -223,7 +226,7 @@ String WiGPS::latitude(void){
      * last updated data in the memory
      * in the format of the String d
      */
-    
+
     String d(latitudeDeg);
     String m(latitudeMin);
     String s(latitudeSec);
@@ -240,7 +243,7 @@ String WiGPS::longitude(void){
      * last updated data in the memory
      * in the format of the String d
      */
-    
+
     String d(longitudeDeg);
     String m(longitudeMin);
     String s(longitudeSec);
@@ -257,7 +260,7 @@ String WiGPS::speed(void){
      * last updated data in the memory
      * in the format of the String d (km/h)
      */
-    
+
     String s((int)(KMKNOT*Speed));
     String f = s + String(" km/h");
     return f;
@@ -270,7 +273,7 @@ String WiGPS::course(void){
      * last updated data in the memory
      * in the format of the String d
      */
-    
+
     String s(Course);
     char c = DEGREE_CHAR;
     String f = s + String(c);
@@ -282,7 +285,7 @@ WiGPS::~WiGPS(){
      * This destroys the created
      * SoftwareSerial object.
      */
-    
+
     //delete serialPort;
 }
 

--- a/WiGPS.h
+++ b/WiGPS.h
@@ -1,27 +1,30 @@
 /*
  Copyright 2013 Daniele Faugiana
- 
+
  This file is part of "WiGPS Arduino Library".
- 
+
  "WiGPS Arduino Library" is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  "WiGPS Arduino Library" is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with "WiGPS Arduino Library". If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef _WIGPS_H
 #define _WIGPS_H
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <arduino.h>
+#elif defined(SPARK)
 #include "application.h" //needs to be placed in extra classes
-//#include <arduino.h>
-//#include <SoftwareSerial.h>
+#endif
 
 #include "GPRMC.h"
 
@@ -45,8 +48,13 @@
  * ERROR CODES
  **************/
 
+#if !defined TRUE
 #define TRUE 1
+#endif
+
+#if !defined FALSE
 #define FALSE 0
+#endif
 
 /*************
  * TYPEDEFS
@@ -54,71 +62,70 @@
 
 typedef unsigned int uint;
 typedef unsigned char uchar;
-//typedef SoftwareSerial* Port;
 
 class WiGPS {
-    
+
 private:
-    
+
     /***************
      * PRIVATE VARS
      ***************/
-    
+
     //Port serialPort;            // A pointer to the serial port the GPS communicates through
     uint portType;              // Port type, see upside to understand types
     uint powerPort;             // The pin Arduino uses to activate/deactivate the GPS
     bool powerState;            // Power state of the GPS
-    
+
     int hours;                  // Last UTC time data from the GPS
     int minutes;
     int seconds;
     //int milliseconds;
-    
+
     int day;                    // Last UTC date data from the GPS
     int month;
     int year;
-    
+
     int latitudeDeg;            // Last Latitude data from the GPS
     int latitudeMin;
     int latitudeSec;
     char latitudeRef;
-    
+
     int longitudeDeg;           // Last Longitude data from the GPS
     int longitudeMin;
     int longitudeSec;
     char longitudeRef;
-    
+
     int Speed;                  // Last speed from the GPS (km/h)
     int Course;                 // Last course over ground (degrees from the north)
-    
+
     int dataReady;              // Data ready to be read
-    
+
     /******************
      * PRIVATE METHODS
      ******************/
-    
+
     void parseGPRMC(GPRMC*);        // Extract data from the GPRMC String
-    
+
 public:
-    
+
     /*****************
      * PUBLIC METHODS
      *****************/
-    
+
     WiGPS(int);
     void init(int);
-    
+
     int on(void);                   // Powers on the GPS module
     int off(void);                  // Turns off the GPS module and stop tracking data
     bool update(void);              // Starts fetching data from the GPS.
-    
+
     String time(void);              // Returns an Arduino String object for the UTC time
     String date(void);              // Returns an Arduino String object for the UTC date
     String latitude(void);          // Returns an Arduino String object for the latitude
     String longitude(void);         // Returns an Arduino String object for the longitude
     String speed(void);             // Returns an Arduino String object for the speed
     String course(void);            // Returns an Arduino String object for the course
-    
+
     ~WiGPS();
 };
 


### PR DESCRIPTION
Particle now has an IDE definition for detecting platform - this patch integrates https://community.particle.io/t/spark-definition-now-available/5545 and swaps some include orders around so that a raw inclusion of this library will compile right away!

Testing for TRUE/FALSE definitions as well as these were already defined in the Particle web IDE. Also cleaned up a few trailing spaces, as they made for some annoying pink highlights in my code editor.

The https://github.com/gercunderscore4/WiGPS fork makes some changes to GP-635T handling but is incompatible with Particle at this time, so I chose to fork this repo instead.
